### PR TITLE
Support GHC 7.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cabal-dev
 .project
 *~
 .hub
+.stack-work

--- a/aws-cloudfront-signer.cabal
+++ b/aws-cloudfront-signer.cabal
@@ -1,5 +1,5 @@
 Name:               aws-cloudfront-signer
-Version:            1.1.0.2
+Version:            1.1.0.3
 Synopsis:           For signing AWS CloudFront HTTP URL requests
 Description:        Provides functions for reading in the signing keys from file and making up time-limited, signed URLS for accessing AWS CloudFront-hosted files.
 Homepage:           http://github.com/iconnect/aws-cloudfront-signer
@@ -27,7 +27,7 @@ library
     Hs-Source-Dirs: src
 
     Build-depends:
-        RSA                  >= 1.2.2.0  && < 2,
+        RSA                  >= 1.2.2.0        ,
         asn1-types           >= 0.2.0          ,
         asn1-encoding        >= 0.8.0          ,
         base                 == 4.*            ,

--- a/aws-cloudfront-signer.cabal
+++ b/aws-cloudfront-signer.cabal
@@ -14,6 +14,10 @@ Build-type:         Simple
 
 Cabal-version:      >= 1.14
 
+
+flag time15
+     default: True
+
 Source-repository this
     type:           git
     location:       https://github.com/iconnect/aws-cloudfront-signer.git
@@ -33,9 +37,15 @@ library
         base                 == 4.*            ,
         base64-bytestring    == 1.0.*          ,
         bytestring           >= 0.9            ,
-        crypto-pubkey-types  >= 0.4.0          ,
-        old-locale           >= 1              ,
-        time                 >= 1.1.4
+        crypto-pubkey-types  >= 0.4.0
+
+    if flag(time15)
+        Build-depends:
+            time                 >= 1.5.0
+    else
+        Build-depends:
+            old-locale           >= 1              ,
+            time                 >= 1.1.4
 
     Exposed-modules:
         Aws.CloudFront.Signer

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.10
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
cc @adamgundry @cdornan 

This ships support for GHC 7.10.2.

I have gone naughty and used CPP to get rid on the constrain over `RSA < 2` :imp: 

`stack.yml` added for ease of adoption.

Thoughts?
